### PR TITLE
Add `localtime` option to un-UTC parsed dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Then in your code:
     var Metalsmith = require('Metalsmith');
     var dateInFilename = require('metalsmith-date-in-filename');
     Metalsmith(__dirname)
-        .use(dateInFilename({override: true}))
+        .use(dateInFilename({
+            override: true,
+            // Use localtime: true to treat parsed dates as local instead of UTC
+            localtime: true
+        }))
         .build();
 
 ... alternatively, you can pass just a boolean to the plugin, and the `override` setting will be set to it:
@@ -42,7 +46,10 @@ CLI Usage
 
     {
         "plugins": {
-            "metalsmith-date-in-filename": {"override": true}
+            "metalsmith-date-in-filename": {
+                "override": true
+                "localtime": true
+            }
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 var _ = require('lodash');
+var timezoneOffset = (new Date()).getTimezoneOffset();
 
 module.exports = function(options){
   var override = (('boolean' === typeof options) && options) || ('object' === typeof options && options.override) || false;
+  var localtime = 'object' === typeof options && options.localtime || false;
   return function drafts(files, metalsmith, done){
     _.forEach(files, function (fileMeta, fileName) {
       if (!override && fileMeta.date) {
           return;
       }
-      var m;
+      var m, oldDate = fileMeta.date;
       if (m = fileName.match(/(\d{4}-\d{2}-\d{2})/)) {
           fileMeta.date = new Date(m[1]);
       } else if (m = fileName.match(/(\d{8})/)) {
@@ -16,6 +18,10 @@ module.exports = function(options){
               m[1].substr(4, 2) +'-'+
               m[1].substr(6, 2)
           );
+      }
+
+      if (localtime && oldDate !== fileMeta.date) {
+          fileMeta.date.setMinutes(timezoneOffset);
       }
     });
     var filesWithoutContents = _.zipObject(_.map(files, function (fileMeta, fileName) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Incorporate date information on filename into metadata.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "TZ=America/Chicago mocha"
   },
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -139,4 +139,28 @@ describe('metalsmith-date-in-filename', function () {
             })
             .build(buildDone(done));
     });
+
+    describe('localtime is correct', function() {
+        // These tests depend on the TZ environment var
+
+        it('when local date differs by a day from utc date', function(done) {
+            var metalsmith = Metalsmith('test/fixtures/single_post_with_disparate_dates');
+            metalsmith
+                .use(dateInFilename({
+                  override: true,
+                  localtime: true
+                }))
+                .use(function (files, metalsmith, done) {
+                    _.forEach(files, function (fileMeta, fileName) {
+                        switch (fileName) {
+                            case '2014-10-02-one.md':
+                                assert.equal(2, fileMeta.date.getDate());
+                                break;
+                        }
+                    });
+                    done();
+                })
+                .build(buildDone(done));
+        });
+    });
 });


### PR DESCRIPTION
Fix #2 while maintaining backwards compatibility

[When date strings are parsed with `new Date()` they are always treated as UTC](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Parameters).  The resulting time will also be midnight; for example `2017-10-08` is parsed as `2017-10-08T00:00:00.000Z`.  When using this resulting date in a timezone that is a negative offset, ie `America/Chicago` which is `-05:00`, you will end up with the previous day.  A `.getDate()` called on a date parsed from `2017-10-08` will yield `7` in `America/Chicago`.

If UTC wasn't the intention when parsing dates @sanx , I would reject this PR and instead fix the instantiation of `new Date()` to use 3 parameters (for year, month, day) as these are always assumed to be localtime.